### PR TITLE
feat: automatically display latest news items (resolves #17)

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const htmlMinTransform = require('./src/transforms/html-min.js');
 const parseTransform = require('./src/transforms/parse.js');
 const dateFilter = require('./src/filters/date-filter.js');
+const limitFilter = require('./src/filters/limit-filter.js');
 const markdownFilter = require('./src/filters/markdown-filter.js');
 const w3DateFilter = require('./src/filters/w3-date-filter.js');
 
@@ -51,6 +52,7 @@ module.exports = eleventyConfig => {
 	eleventyConfig.addFilter('dateFilter', dateFilter);
 	eleventyConfig.addFilter('markdownFilter', markdownFilter);
 	eleventyConfig.addFilter('w3DateFilter', w3DateFilter);
+	eleventyConfig.addFilter('limit', limitFilter);
 
 	// Passthrough file copy.
 	eleventyConfig.addPassthroughCopy({'src/_includes/static/css': 'css'});

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -1,3 +1,72 @@
+{% extends 'layouts/base.njk' %}
+
 {% set pageType = 'page--home' %}
 
-{% include 'layouts/page.njk' %}
+{% block content %}
+    <article class="container">
+        <header>
+            <div class="container inner">
+                <h1>{{ title }}</h1>
+                {% if intro %}
+                <div class="intro">{{ intro | markdownFilter | safe }}</div>
+                {% endif %}
+            </div>
+        </header>
+        {%- if sections %}
+            {%- for section in sections %}
+            {% set sectionTitle = '' %}
+            {% set sectionContent = '' %}
+            {% set desktopWidth = 'section--full' %}
+            {% set imageOrderDesktop = '' %}
+
+            {% if section.title %}
+                {% set sectionTitle = section.title %}
+            {% endif %}
+            {% if section.content %}
+                {% set sectionContent = section.content %}
+            {% endif %}
+            {% if section.desktopWidth %}
+                {% set desktopWidth = 'section--' + section.desktopWidth %}
+            {% endif %}
+            {% if section.imageOrderDesktop %}
+                {% set imageOrderDesktop = section.imageOrderDesktop %}
+            {% endif %}
+        <section id="{{ sectionTitle | slug }}" class="section
+        {{ desktopWidth }}
+        {{ 'section--image' if section.image }}
+        {{ section.desktopAlignment if section.desktopAlignment }}
+        {{ 'section--bg-' + section.backgroundColor if section.backgroundColor }}
+        {{ 'section--fg-' + section.textColor if section.textColor }}"> 
+            <div class="container">
+                {% if section.image and section.imageOrder == 'start' %}
+                <figure class="{{ imageOrderDesktop }} {{ 'shadow-' + section.imageShadow if section.imageShadow else 'indigo-500' }}">
+                    <img src="{{ section.image }}" {% if section.image2x %}srcset="{{ section.image }} 1x, {{ section.image2x }} 2x" {% endif %}alt="{{ section.imageAltText }}" width="640" height="427" />
+                </figure>
+                {% endif %}
+                <div class="section__content">
+                    {% if section.borderColor %}<span class="hr hr--{{ section.borderColor }}"></span>{% endif %}
+                    <h2>{{ sectionTitle | safe }}</h2>
+                    {% if sectionTitle == 'Latest news' %}
+                        {% if collections.posts.length %}
+                            {% for item in collections.posts | limit(2) %}
+                            {% include 'partials/components/post-excerpt.njk' %}
+                            {% endfor %}
+                            <p><a href="/news/">View all</a></p>
+                        {% else %}
+                            <p>No news items found.</p>
+                        {% endif %}
+                    {% else %}
+                    {{ sectionContent | markdownFilter | safe }}
+                    {% endif %}
+                </div>
+                {% if section.image and section.imageOrder == 'end' %}
+                <figure class="{{ imageOrderDesktop }} shadow-{{ section.imageShadow if section.imageShadow else 'indigo-500' }}">
+                    <img src="{{ section.image }}" {% if section.image2x %}srcset="{{ section.image }} 1x, {{ section.image2x }} 2x" {% endif %}alt="{{ section.imageAltText }}" width="640" height="427" />
+                </figure>
+                {% endif %}
+            </div>
+        </section>
+            {%- endfor %}
+        {%- endif %}
+    </article>
+{% endblock %}

--- a/src/_includes/partials/components/post-excerpt.njk
+++ b/src/_includes/partials/components/post-excerpt.njk
@@ -1,0 +1,2 @@
+<h3><a href="{{ item.url }}">{{ item.data.title }}</a></h3>
+<p>Published <time datetime="{{ item.data.date | w3DateFilter }}" class="dt-published">{{ item.data.date | dateFilter }}</time></p>

--- a/src/filters/limit-filter.js
+++ b/src/filters/limit-filter.js
@@ -1,0 +1,3 @@
+module.exports = (array, limit) => {
+	return array.slice(0, limit);
+};

--- a/src/index.md
+++ b/src/index.md
@@ -1,5 +1,5 @@
 ---
-layout: layouts/page.njk
+layout: layouts/home.njk
 title: Inclusive Design Research Centre
 eleventyNavigation:
   key: Home
@@ -96,11 +96,7 @@ sections:
     textColor: null
     desktopWidth: third
   - title: Latest news
-    content: |-
-      ### [Continuing Our Work During COVID-19](/news/continuing-our-work-during-covid-19/)
-      Published April 3, 2020
-      ### [We Count – Removing bias and exclusion in the data economy](/news/we-count-removing-bias-and-exclusion-in-the-data-economy/)
-      Published March 18, 2020
+    content: This space intentionally left blank.
     backgroundColor: null
     borderColor: yellow-500
     textColor: null


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR automatically populates the latest news section of the home page with the two most recent news items.

## Steps to test

1. Visit home page.

**Expected behavior:** The latest two news items appear.

## Additional information

The content of the "Latest news" block on the home page now contains the text "This space intentionally left blank."

## Related issues

Resolves #17.
