### PR TITLE
feat: add links to about pages from home (resolves #83)

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -4,12 +4,15 @@ title: Inclusive Design Research Centre
 intro: >
   An international community of open source developers, designers, researchers,
   educators and co-designers who work together to **proactively ensure that
-  emerging technology and practices are designed inclusively**. 
+  emerging technology and practices are designed inclusively**.
 
 
   Established in 1993, the Inclusive Design Research Centre (IDRC) coordinates
   the [Inclusive Design Institute](https://inclusivedesign.ca/). Both were
   founded by Dr. Jutta Treviranus with the help of her team and community.
+
+
+  [Learn more about us](/about/)
 headerBgColor: indigo-100
 sections:
   - image2x: /media/what-we-do@2x.jpg
@@ -49,10 +52,8 @@ sections:
       to ability, language, culture, gender, age, and other forms of human
       difference.
 
-      ### Learn more
 
-      [The three dimensions of inclusive
-      design](https://medium.com/fwd50/the-three-dimensions-of-inclusive-design-part-one-103cad1ffdc2)
+      [Learn more about our philosophy](/about/philosophy/)
     backgroundColor: blue-500
     borderColor: white
     textColor: black
@@ -73,7 +74,7 @@ sections:
     content: >-
       ### [Inclusive Design Guide](https://guide.inclusivedesign.ca/)
 
-      An open, evolving guide to the process of inclusive design. 
+      An open, evolving guide to the process of inclusive design.
 
       ### [Inclusive Learning Design
       Handbook](https://handbook.floeproject.org/)


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Adds links to About and Philosophy pages from home page.

## Steps to test

Review deploy preview.

## Additional information

Not applicable.

## Related issues

Resolves #83.
