### PR TITLE
feat: update paths to news page and news items

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,22 +1,25 @@
-https://idrc.ocad.ca/*                                                                  https://idrc.ocadu.ca/:splat                                        301!
-https://www.idrc.ocad.ca/*                                                              https://idrc.ocadu.ca/:splat                                        301!
-https://www.idrc.ocadu.ca/*                                                             https://idrc.ocadu.ca/:splat                                        301!
-/about-the-idrc                                                                         /                                                                   302
-/about-the-idrc/idrc-news                                                               /news/                                                              301            
-/about-the-idrc/idrc-news/534-continuing-our-work-during-covid-19                       /news/continuing-our-work-during-covid-19/                          301
-/about-the-idrc/idrc-news/533-we-count-removing-bias-and-exclusion-in-the-data-economy  /news/we-count-removing-bias-and-exclusion-in-the-data-economy/     301
-/about-the-idrc/idrc-news/*                                                             https://legacy.idrc.ocadu.ca/about-the-idrc/idrc-news/:splat        302 # Temporarily redirect all legacy news items to legacy site.
-/about-the-idrc/contact-us                                                              /#contact-us                                                        302
-/about-the-idrc/employment-opportunities                                                /#job-postings                                                      302
-/about-the-idrc/getinvolved                                                             /#get-involved                                                      302
-/about-the-idrc/*                                                                       https://legacy.idrc.ocadu.ca/about-the-idrc/:splat                  302 # Temporarily redirect all subpages of "About the IDRC" to the legacy site.
-/research-and-development                                                               /projects-and-tools/                                                301
-/research-and-development/*                                                             https://legacy.idrc.ocadu.ca/research-and-development/:splat        302
-/resources                                                                              /#our-resources                                                     302
-/workshops-aamp-trainings                                                               https://legacy.idrc.ocadu.ca/workshops-aamp-trainings               302 # Temporarily redirect "Education" page to legacy site.
-/policy                                                                                 https://legacy.idrc.ocadu.ca/policy                                 302 # Temporarily redirect "Policy" page to legacy site.
-/policy/*                                                                               https://legacy.idrc.ocadu.ca/policy/:splat                          302 # Temporarily redirect all subpages of "Policy" to the legacy site.
-/services                                                                               /#services-we-offer                                                 302
-/services/33-services/57-vision-technology-service                                      /vision-technology-service/                                         301
-/services/34-services/consultation/58-employment-accommodation-services                 /vision-technology-service/                                         301
-/websavvy/                                                                              /consulting/
+https://idrc.ocad.ca/*                                                                  https://idrc.ocadu.ca/:splat                                            301!
+https://www.idrc.ocad.ca/*                                                              https://idrc.ocadu.ca/:splat                                            301!
+https://www.idrc.ocadu.ca/*                                                             https://idrc.ocadu.ca/:splat                                            301!
+/about-the-idrc                                                                         /about                                                                  301
+/news                                                                                   /about/news/                                                            301            
+/about-the-idrc/idrc-news                                                               /about/news/                                                            301            
+/news/continuing-our-work-during-covid-19                                               /about/news/continuing-our-work-during-covid-19/                        301
+/about-the-idrc/idrc-news/534-continuing-our-work-during-covid-19                       /about/news/continuing-our-work-during-covid-19/                        301
+/news/we-count-removing-bias-and-exclusion-in-the-data-economy                          /about/news/we-count-removing-bias-and-exclusion-in-the-data-economy/   301
+/about-the-idrc/idrc-news/533-we-count-removing-bias-and-exclusion-in-the-data-economy  /about/news/we-count-removing-bias-and-exclusion-in-the-data-economy/   301
+/about-the-idrc/idrc-news/*                                                             https://legacy.idrc.ocadu.ca/about-the-idrc/idrc-news/:splat            302 # Temporarily redirect all legacy news items to legacy site.
+/about-the-idrc/contact-us                                                              /#contact-us                                                            302
+/about-the-idrc/employment-opportunities                                                /#job-postings                                                          302
+/about-the-idrc/getinvolved                                                             /#get-involved                                                          302
+/about-the-idrc/*                                                                       https://legacy.idrc.ocadu.ca/about-the-idrc/:splat                      302 # Temporarily redirect all subpages of "About the IDRC" to the legacy site.
+/research-and-development                                                               /projects-and-tools/                                                    301
+/research-and-development/*                                                             https://legacy.idrc.ocadu.ca/research-and-development/:splat            302
+/resources                                                                              /#our-resources                                                         302
+/workshops-aamp-trainings                                                               https://legacy.idrc.ocadu.ca/workshops-aamp-trainings                   302 # Temporarily redirect "Education" page to legacy site.
+/policy                                                                                 https://legacy.idrc.ocadu.ca/policy                                     302 # Temporarily redirect "Policy" page to legacy site.
+/policy/*                                                                               https://legacy.idrc.ocadu.ca/policy/:splat                              302 # Temporarily redirect all subpages of "Policy" to the legacy site.
+/services                                                                               /#services-we-offer                                                     302
+/services/33-services/57-vision-technology-service                                      /vision-technology-service/                                             301
+/services/34-services/consultation/58-employment-accommodation-services                 /vision-technology-service/                                             301
+/websavvy/                                                                              /consulting/                                                            301

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -326,7 +326,7 @@ collections:
     label_singular: "News Item"
     folder: "src/news"
     slug: "{{slug}}"
-    preview_path: "/news/{{slug}}"
+    preview_path: "/about/news/{{slug}}"
     create: true
     fields:
       - {label: "Layout", name: "layout", widget: "hidden", default: "layouts/single--news.njk"}

--- a/src/news.md
+++ b/src/news.md
@@ -11,7 +11,7 @@ headerTextColor: black
 secondaryNavigation:
   key: About
   label: More about us
-permalink: "/news/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}/{% endif %}"
+permalink: "/about/news/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}/{% endif %}"
 pagination:
   data: collections.news
   size: 6

--- a/src/news/news.json
+++ b/src/news/news.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/single--news.njk",
-    "permalink": "/news/{{ title | slug }}/",
+    "permalink": "/about/news/{{ title | slug }}/",
     "headerBgColor": "white",
     "author": "IDRC Team"
 }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This PR changes all of the news URLs from `/news/*` to `/about/news/*` and adds appropriate redirects.

## Steps to test

1. Visit https://deploy-preview-86--idrc.netlify.app/news/
2. Visit https://deploy-preview-86--idrc.netlify.app/news/continuing-our-work-during-covid-19/

**Expected behavior:** Both should redirect to the same location with `/about/news/` at the start of the URL paths instead of just `/news/`.

## Additional information

Not applicable.

## Related issues

Follow-up to #57 and #74.
