### PR TITLE
fix: remove images from project and tool short descriptions

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -416,7 +416,7 @@ collections:
       - {label: "Layout", name: "layout", widget: "hidden", default: "layouts/base.njk"}
       - {label: "Title", name: "title", widget: "string", required: true}
       - {label: "Short Name", name: "shortName", widget: "string", required: false}
-      - {label: "Description", name: "description", widget: "markdown", required: true}
+      - {label: "Description", name: "description", widget: "markdown", buttons: ['bold', 'italic'], editor_components: [], required: true}
       - {label: "Tags", name: "tags", widget: "list", required: false}
       - {label: "Link", name: "link", widget: "string", required: true}
       - {label: "Body", name: "body", widget: "markdown", required: false}
@@ -431,7 +431,7 @@ collections:
       - {label: "Layout", name: "layout", widget: "hidden", default: "layouts/base.njk"}
       - {label: "Title", name: "title", widget: "string", required: true}
       - {label: "Short Name", name: "shortName", widget: "string", required: false}
-      - {label: "Description", name: "description", widget: "markdown", required: true}
+      - {label: "Description", name: "description", widget: "markdown", buttons: ['bold', 'italic'], editor_components: [], required: true}
       - {label: "Tags", name: "tags", widget: "list", required: false}
       - {label: "Link", name: "link", widget: "string", required: true}
       - {label: "Body", name: "body", widget: "markdown", required: false}

--- a/src/projects/future-of-work-and-disability.md
+++ b/src/projects/future-of-work-and-disability.md
@@ -3,9 +3,6 @@ layout: layouts/base.njk
 title: Future of Work and Disability
 shortName: FWD
 description: >-
-  ![Future of Work and Disability logo](/media/fwd-logoe-for-processing-4x.png)
-
-
   The Future of Work and Disability project brought together a study group of fifteen people, many with lived experience of disabilities, with researchers, artificial intelligence (AI) experts, data scientists, employment organizations and others engaged in the data ecosystem. The goal of the group was to understand and examine intersecting topics of AI, automation, standards and employment as they mainly relate to persons with disabilities.
 link: https://wecount.inclusivedesign.ca/views/fwd/
 ---

--- a/src/projects/future-of-work-equitable-digital-systems.md
+++ b/src/projects/future-of-work-equitable-digital-systems.md
@@ -3,9 +3,6 @@ layout: layouts/base.njk
 title: "Future of Work: Equitable Digital Systems"
 shortName: EDS
 description: >-
-  ![Equitable Digital Systems logo](/media/eds-colored-03.png)
-
-
   *Equitable Digital Systems* focuses on examining the accessibility of the digital tools and systems we use for work. We will use our shared experiences to make recommendations for Accessibility Standards Canada on how to prevent accessibility barriers at work from information and communication systems.
 link: https://idrc.ocadu.ca/eds/
 ---

--- a/src/projects/odd.md
+++ b/src/projects/odd.md
@@ -2,10 +2,6 @@
 layout: layouts/base.njk
 title: ODD
 description: >-
-  ![ODD: Optimizing Diversity with Disability
-  logo](/media/screen-shot-2021-11-01-at-8.41.18-pm.png)
-
-
   The goal of ODD is to investigate bias in hiring algorithms using non-disability specific and synthesized disability specific employment data.
 link: https://idrc.ocadu.ca/odd
 ---

--- a/src/projects/we-count.md
+++ b/src/projects/we-count.md
@@ -2,9 +2,6 @@
 title: We Count
 shortName: false
 description: >-
-  ![We Count logo](/media/we-count-logo_colour_no-background.png)
-
-
   Ensuring that data science, AI and machine learning are equitable and that people with disabilities can help to shape the future of data science.
 tags: []
 link: https://wecount.inclusivedesign.ca/


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Prevents project short descriptions from including any content other than basic formatting (bold and italics). Removes images from existing project descriptions.

## Steps to test

1. Review projects page on deploy preview.
2. Review CMS admin for projects and tools.

**Expected behavior:**

1. Projects and tools page looks good again.
2. Images cannot be inserted into project or tool descriptions and only bold and italic toolbar buttons are available when editing project or tool descriptions.

## Additional information

Not applicable.

## Related issues

Not applicable.