### PR TITLE
feat: redirect legacy 443-whatisinclusivedesign to /about/philosophy/

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -29,5 +29,6 @@ https://websavvy.idrc.ocad.ca/*                                                 
 /services/33-services/57-vision-technology-service                                      /vision-technology-service/                                             301
 /services/34-services/consultation/58-employment-accommodation-services                 /vision-technology-service/                                             301
 /websavvy/                                                                              /consulting/                                                            301
+/index.php/resources/idrc-online/library-of-papers/443-whatisinclusivedesign            /about/philosophy/                                                      301
 /index.php/resources/idrc-online/*                                                      https://legacy.idrc.ocadu.ca/index.php/resources/idrc-online/:splat     302 # Temporary redirect "IDRC Online" page to legacy site.
 


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Jutta has requested the old legacy page be redirected to the new Pilosophy page.

## Steps to test

1. Open https://idrc.ocadu.ca/index.php/resources/idrc-online/library-of-papers/443-whatisinclusivedesign
2. Confirm it redirects to https://idrc.ocadu.ca/about/philosophy