### PR TITLE
Rename python package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.16.0-alpine AS builder
 
-RUN apk add --no-cache python make git g++
+RUN apk add --no-cache python3 make git g++
 
 WORKDIR /app
 


### PR DESCRIPTION
This docker image cannot currently be built because the 'python' package no longer exists. The new name appears to be 'python3'. I was able to build the image with this change.