### PR TITLE
Add project thumbnail image alt text (resolves #495)

### DIFF
--- a/src/_includes/layouts/projects.njk
+++ b/src/_includes/layouts/projects.njk
@@ -18,7 +18,11 @@
                         {% for project in collections.projects %}
                         <article class="project">
                             {% if project.data.thumbnailImage %}
-                            <img class="thumbnail" src="{{ project.data.thumbnailImage }}" role="presentation" alt="" />
+                            <img class="thumbnail" src="{{ project.data.thumbnailImage }}" role="presentation" alt="{{
+                                project.data.thumbnailAltText
+                                if project.data.thumbnailAltText
+                                else "Thumbnail image for " + project.data.projectName
+                            }}" />
                             {% else %}
                             <img class="thumbnail" src="/assets/images/project-placeholder.svg" role="presentation" alt="" />
                             {% endif %}

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -436,7 +436,7 @@ collections:
       - {label: "Parent Page", name: "parentPageTitle", widget: "relation", collection: "projects", value_field: "title", search_fields: [title], required: false, hint: "This is required for sub-pages of a project to define the sub-page hierarchy."}
       - {label: "Subpage Order", name: "subPageOrder", widget: "number", required: false, hint: "Hint: if using this, all sub-pages at the same level should have an order number specified. Leave blank to have sub-pages appear in alphabetical order. "}
       - {label: "Thumbnail Image", name: "thumbnailImage", widget: "image", required: false, hint: "Suggested size: 680x494px. Images not fitting this aspect ratio will appear stretched."}
-      - {label: "Thumbnail Image Alt Text", name: "thumbnailAltText", widget: "string", required: false, hint: "Hint: thumbnail images will have alt text 'Thumbnail image for [Project name]' when this field is left empty."}
+      - {label: "Thumbnail Image Alt Text", name: "thumbnailAltText", widget: "string", required: false, hint: "Hint: If alt text is left blank, 'Thumbnail image for [Project Name]' will be used by default."}
       - {label: "Project Listing Description", name: "description", widget: "markdown", required: false, editor_components: ["image"], hint: "This is text that appears for a project in the projects listing. This description is not required for sub-pages."}
       - {label: "External Project Website", name: "link", widget: "string", required: false, hint: "This is not required for sub-pages."}
       - {label: "Body", name: "body", required: false, widget: "markdown", hint: "This is the content that appears for a project page hosted on the IDRC site."}

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -436,6 +436,7 @@ collections:
       - {label: "Parent Page", name: "parentPageTitle", widget: "relation", collection: "projects", value_field: "title", search_fields: [title], required: false, hint: "This is required for sub-pages of a project to define the sub-page hierarchy."}
       - {label: "Subpage Order", name: "subPageOrder", widget: "number", required: false, hint: "Hint: if using this, all sub-pages at the same level should have an order number specified. Leave blank to have sub-pages appear in alphabetical order. "}
       - {label: "Thumbnail Image", name: "thumbnailImage", widget: "image", required: false, hint: "Suggested size: 680x494px. Images not fitting this aspect ratio will appear stretched."}
+      - {label: "Thumbnail Image Alt Text", name: "thumbnailAltText", widget: "string", required: false, hint: "Hint: thumbnail images will have alt text 'Thumbnail image for [Project name]' when this field is left empty."}
       - {label: "Project Listing Description", name: "description", widget: "markdown", required: false, editor_components: ["image"], hint: "This is text that appears for a project in the projects listing. This description is not required for sub-pages."}
       - {label: "External Project Website", name: "link", widget: "string", required: false, hint: "This is not required for sub-pages."}
       - {label: "Body", name: "body", required: false, widget: "markdown", hint: "This is the content that appears for a project page hosted on the IDRC site."}

--- a/src/projects/community-led-codesign.md
+++ b/src/projects/community-led-codesign.md
@@ -1,4 +1,5 @@
 ---
+projectName: Community-Led Co-design Kit
 title: Community-Led Co-design Kit
 permalink: /projects/community-led-codesign-kit/
 shortName: false

--- a/src/projects/ecocultural-mapping.md
+++ b/src/projects/ecocultural-mapping.md
@@ -1,4 +1,5 @@
 ---
+projectName: Ecocultural Mapping Project
 title: Ecocultural Mapping Project
 permalink: /projects/ecocultural-mapping-project/
 shortName: false


### PR DESCRIPTION
Add extra field for project thumbnail image alt text and set default alt text.

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

<!-- Description of the pull request -->

## Steps to test

1. Go to projects-and-tools page, and check if the thumbnails have alt text in the format: "Thumbnail image for [Project Name] by default.
2. Go to admin panel and update one of the projects' alt text 
3. Go back to projects and tools page and check that custom alt text is applied

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->

Resolve #495 
