### PR TITLE
GH-591: Add custom widget for file upload

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -29,13 +29,13 @@ collections:
           - {label: "SEO Meta Title", name: "metaTitle", widget: "string", required: false}
           - {label: "SEO Meta Description", name: "metaDesc", widget: "string", required: false}
           - {label: "Social Image", name: "socialImage", widget: "image", required: false}
-          - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image"]}
+          - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image", "file"]}
           - label: "Sections"
             name: "sections"
             widget: "list"
             fields:
               - {label: "Title", name: "title", widget: "string", required: true}
-              - {label: "Content", name: "content", widget: "markdown", required: true, editor_components: ["image"]}
+              - {label: "Content", name: "content", widget: "markdown", required: true, editor_components: ["image", "file"]}
               - label: "Text Colour"
                 name: "textColor"
                 widget: "select"
@@ -147,7 +147,7 @@ collections:
           - {label: "SEO Meta Title", name: "metaTitle", widget: "string", required: false}
           - {label: "SEO Meta Description", name: "metaDesc", widget: "string", required: false}
           - {label: "Social Image", name: "socialImage", widget: "image", required: false}
-          - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image"]}
+          - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image", "file"]}
           - {label: "Header Background Colour", name: "headerBgColor", widget: "hidden", default: "blue-200"}
           - {label: "Header Border Color", name: "headerBorderColor", widget: "hidden", default: "blue-500"}
           - {label: "Header Text Color", name: "headerTextColor", widget: "hidden", default: "black"}
@@ -191,7 +191,7 @@ collections:
       - {label: "SEO Meta Title", name: "metaTitle", widget: "string", required: false}
       - {label: "SEO Meta Description", name: "metaDesc", widget: "string", required: false}
       - {label: "Social Image", name: "socialImage", widget: "image", required: false}
-      - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image"]}
+      - {label: "Intro", name: "intro", widget: "markdown", required: false, editor_components: ["image", "file"]}
       - label: "Header Background Colour"
         name: "headerBgColor"
         widget: "select"
@@ -438,7 +438,7 @@ collections:
       - {label: "Subpage Order", name: "subPageOrder", widget: "number", required: false, hint: "Hint: if using this, all sub-pages at the same level should have an order number specified. Leave blank to have sub-pages appear in alphabetical order. "}
       - {label: "Thumbnail Image", name: "thumbnailImage", widget: "image", required: false, hint: "Suggested size: 680x494px. Images not fitting this aspect ratio will appear stretched."}
       - {label: "Thumbnail Image Alt Text", name: "thumbnailAltText", widget: "string", required: false, hint: "If alt text is left blank, 'Thumbnail image for [Project Name]' will be used by default."}
-      - {label: "Project Listing Description", name: "description", widget: "markdown", required: false, editor_components: ["image"], hint: "This is text that appears for a project in the projects listing. This description is not required for sub-pages."}
+      - {label: "Project Listing Description", name: "description", widget: "markdown", required: false, editor_components: ["image", "file"], hint: "This is text that appears for a project in the projects listing. This description is not required for sub-pages."}
       - {label: "External Project Website", name: "link", widget: "string", required: false, hint: "This is not required for sub-pages."}
       - {label: "Body", name: "body", required: false, widget: "markdown", hint: "This is the content that appears for a project page hosted on the IDRC site."}
   - name: "tools"
@@ -452,7 +452,7 @@ collections:
       - {label: "Layout", name: "layout", widget: "hidden", default: "layouts/single--tool.njk"}
       - {label: "Title", name: "title", widget: "string", required: true}
       - {label: "Short Name", name: "shortName", widget: "string", required: false}
-      - {label: "Description", name: "description", widget: "markdown", required: true, editor_components: ["image"]}
+      - {label: "Description", name: "description", widget: "markdown", required: true, editor_components: ["image", "file"]}
       - {label: "Tags", name: "tags", widget: "list", required: false}
       - {label: "Link", name: "link", widget: "string", required: true}
   - label: "Globals"

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -259,7 +259,7 @@ collections:
         default: []
         fields:
           - {label: "Title", name: "title", widget: "string", required: true}
-          - {label: "Content", name: "content", widget: "markdown", required: true, editor_components: ["image"]}
+          - {label: "Content", name: "content", widget: "markdown", required: true, editor_components: ["image", "file"]}
           - label: "Text Colour"
             name: "textColor"
             widget: "select"

--- a/src/admin/previews.js
+++ b/src/admin/previews.js
@@ -340,3 +340,33 @@ CMS.registerEditorComponent({
 		);
 	}
 });
+
+CMS.registerEditorComponent({
+	label: "File",
+	id: "file",
+	fromBlock: match =>
+		match && {
+			file: match[2],
+			text: match[1],
+		},
+	toBlock: ({ text, file }) =>
+		`[${text || ""}](${file || ""})`,
+	toPreview: (obj) => {
+		return <a href={obj.file || ""}>{obj.text}</a>;
+	},
+	pattern: /^\[(.*)\]\((.*?)\)$/,
+	fields: [
+		{
+			label: "File",
+			name: "file",
+			widget: "file",
+			media_library: {
+				allow_multiple: false,
+			},
+		},
+		{
+			label: "Link Text",
+			name: "text",
+		}
+	],
+});

--- a/src/admin/previews.js
+++ b/src/admin/previews.js
@@ -342,31 +342,31 @@ CMS.registerEditorComponent({
 });
 
 CMS.registerEditorComponent({
-	label: "File",
-	id: "file",
+	label: 'File',
+	id: 'file',
 	fromBlock: match =>
 		match && {
 			file: match[2],
-			text: match[1],
+			text: match[1]
 		},
 	toBlock: ({ text, file }) =>
-		`[${text || ""}](${file || ""})`,
+		`[${text || ''}](${file || ''})`,
 	toPreview: (obj) => {
-		return <a href={obj.file || ""}>{obj.text}</a>;
+		return <a href={obj.file || ''}>{obj.text}</a>;
 	},
 	pattern: /^\[(.*)\]\((.*?)\)$/,
 	fields: [
 		{
-			label: "File",
-			name: "file",
-			widget: "file",
+			label: 'File',
+			name: 'file',
+			widget: 'file',
 			media_library: {
-				allow_multiple: false,
-			},
+				allow_multiple: false
+			}
 		},
 		{
-			label: "Link Text",
-			name: "text",
+			label: 'Link Text',
+			name: 'text'
 		}
-	],
+	]
 });


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

See #591 for details.

## Steps to test

1. Sign into the authoring interface
2. Create or update an existing project
3. On body section, press + icon for adding widget, select "File"
4. Select a file from the media folder

**Expected behavior:** <!-- What should happen -->

See an anchor tag to the file gets rendered


## Related issues

Resolves #591 
