### PR TITLE
Update collections' permalink to use file name (resolves #514)

### DIFF
--- a/src/ideas/ideas.json
+++ b/src/ideas/ideas.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/single--idea.njk",
-    "permalink": "/ideas/{{ title | slugify }}/",
+    "permalink": "/ideas/{{ page.fileSlug | slugify }}/",
     "headerBgColor": "white",
     "author": "IDRC Team",
     "thumbnailImage": "/media/default.jpg"

--- a/src/news/news.json
+++ b/src/news/news.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/single--news.njk",
-    "permalink": "/about/news/{{ title | slugify }}/",
+    "permalink": "/about/news/{{ page.fileSlug | slugify }}/",
     "headerBgColor": "white",
     "author": "IDRC Team"
 }

--- a/src/people/people.json
+++ b/src/people/people.json
@@ -1,5 +1,5 @@
 {
     "layout": "layouts/single--person.njk",
-    "permalink": "/about/team/{{ title | slugify }}/",
+    "permalink": "/about/team/{{ page.fileSlug | slugify }}/",
     "headerBgColor": "white"
 }


### PR DESCRIPTION
* [ ] This pull request has been tested by running `npm run test` without errors
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Resolves the Issue described in #514.

## Steps to test

1. Create an instance of either idea, news, or people.
2. Navigate to the new instance by using its file name, like if you created an idea called "example", go to ideas/example/
3. Check that the page is the instance that's created

