### PR TITLE
Fix nav bar banner breakpoint issue (resolves #309)

### DIFF
--- a/src/assets/styles/layout/_header.scss
+++ b/src/assets/styles/layout/_header.scss
@@ -54,7 +54,7 @@
   }
 }
 
-@include breakpoint-down(md) {
+@include breakpoint-down(sm) {
   .banner.banner--menu-visible,
   .page--home .banner.banner--menu-visible {
     --parent-bg: var(--indigo-800);
@@ -64,7 +64,7 @@
   }
 }
 
-@include breakpoint-up(md) {
+@include breakpoint-up(sm) {
   .banner .wrapper {
     padding: 0;
   }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes the issue described in #309.

## Steps to test

1. Shrink the browser to have small view port
2. Open up the menu bar from the nav bar
3. Resize the bowser back to normal view port

**Expected behavior:** <!-- What should happen -->

When the browser is resized back to the normal view port, background colour of the nav bar and its content returns back to way it was

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->

Resolves #309 
