### PR TITLE
Fix sidebar style issue (resolves #624)

### DIFF
--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -26,6 +26,7 @@
   'components/button',
   'components/image',
   'components/nav',
+  'components/nav--secondary',
   'components/pagination',
   'components/metadata';
 

--- a/src/assets/styles/components/_nav--secondary.scss
+++ b/src/assets/styles/components/_nav--secondary.scss
@@ -1,0 +1,99 @@
+.nav--secondary {
+  flex: 0 0 100%;
+  padding-left: calc(var(--gutter) / 2);
+  padding-right: calc(var(--gutter) / 2);
+  position: relative;
+
+  .wrapper {
+    background: var(--fl-bgColor, var(--indigo-200));
+    margin-left: calc(-1 * var(--gutter));
+    padding: rem(40) var(--gutter);
+    width: calc(100% + (2 * var(--gutter)));
+  }
+}
+
+.menu--secondary a {
+  align-items: center;
+  border-bottom: rem(1) solid var(--fl-linkColor, var(--black));
+  display: block;
+  display: flex;
+  flex-direction: row;
+  height: rem(50);
+  justify-content: space-between;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    background: var(--fl-linkColor, var(--indigo-800));
+    border-bottom-color: transparent;
+    box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
+    color: var(--fl-bgColor, var(--white));
+  }
+
+  &:active {
+    background: var(--fl-linkColor, var(--indigo-500));
+    box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
+    color: var(--fl-bgColor);
+  }
+
+  &::after {
+    background: currentColor;
+    content: "";
+    display: inline-block;
+    height: 1.5em;
+    margin-left: 0.125em;
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: 1.5em;
+  }
+
+  &:not([rel="external"])::after {
+    margin-bottom: 0;
+    mask-image: url('../images/internal.svg');
+    width: 1em;
+  }
+
+  &[rel~="external"]::after,
+  &[href^="mailto:"]::after {
+    margin-bottom: 0.125em;
+    mask-image: url('../images/external.svg');
+    width: 1.5em;
+  }
+
+  &[aria-current="page"],
+  &[data-parent="true"] {
+    border-bottom-color: var(--fl-linkColor, var(--indigo-500));
+    box-shadow: inset 0 rem(-1) 0 0 var(--fl-bgColor, var(--indigo-500));
+    font-weight: var(--fw-bold);
+
+    &:hover,
+    &:focus {
+      border-bottom-color: transparent;
+      box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
+    }
+
+    &:active {
+      border-bottom-color: transparent;
+      box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
+      color: var(--fl-bgColor);
+    }
+  }
+}
+
+@include breakpoint-up(md) {
+  .nav--secondary {
+    flex: 0 0 calc(1 / 3 * 100%);
+    margin-bottom: rem(96);
+    margin-top: rem(96);
+
+    &::after {
+      display: none;
+    }
+
+    .wrapper {
+      box-shadow: rem(9) rem(9) 0 0 var(--fl-fgColor, var(--indigo-500));
+      margin-left: 0;
+      width: 100%;
+    }
+  }
+}

--- a/src/assets/styles/components/_nav--secondary.scss
+++ b/src/assets/styles/components/_nav--secondary.scss
@@ -26,19 +26,23 @@
   &:focus {
     background: var(--fl-linkColor, var(--indigo-800));
     border-bottom-color: transparent;
-    box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
+    box-shadow:
+      calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)),
+      var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
     color: var(--fl-bgColor, var(--white));
   }
 
   &:active {
     background: var(--fl-linkColor, var(--indigo-500));
-    box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
+    box-shadow:
+      calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)),
+      var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
     color: var(--fl-bgColor);
   }
 
   &::after {
-    background: currentColor;
-    content: "";
+    background: currentcolor;
+    content: '';
     display: inline-block;
     height: 1.5em;
     margin-left: 0.125em;
@@ -47,21 +51,21 @@
     mask-size: 1.5em;
   }
 
-  &:not([rel="external"])::after {
+  &:not([rel='external'])::after {
     margin-bottom: 0;
     mask-image: url('../images/internal.svg');
     width: 1em;
   }
 
-  &[rel~="external"]::after,
-  &[href^="mailto:"]::after {
+  &[rel~='external']::after,
+  &[href^='mailto:']::after {
     margin-bottom: 0.125em;
     mask-image: url('../images/external.svg');
     width: 1.5em;
   }
 
-  &[aria-current="page"],
-  &[data-parent="true"] {
+  &[aria-current='page'],
+  &[data-parent='true'] {
     border-bottom-color: var(--fl-linkColor, var(--indigo-500));
     box-shadow: inset 0 rem(-1) 0 0 var(--fl-bgColor, var(--indigo-500));
     font-weight: var(--fw-bold);
@@ -69,12 +73,16 @@
     &:hover,
     &:focus {
       border-bottom-color: transparent;
-      box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
+      box-shadow:
+        calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800)),
+        var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-800));
     }
 
     &:active {
       border-bottom-color: transparent;
-      box-shadow: calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)), var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
+      box-shadow:
+        calc(-1 * var(--gutter)) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500)),
+        var(--gutter) rem(-1) 0 rem(1) var(--fl-linkColor, var(--indigo-500));
       color: var(--fl-bgColor);
     }
   }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Side bar appears on some pages have incorrect styles, and this was caused by removing a scss file from this commit: https://github.com/inclusive-design/idrc/pull/405/files#diff-6570bfd166f1b66042ea35a638f670641ce3ffe91cf44c25116675646453e534

Restore the style by restoring the style file.

## Steps to test

1. Click about on the main page, and then navigate to the Overview page
2. Check the side bar menu on the right side

**Expected behavior:** <!-- What should happen -->

The sidebar should have box-shadow with some offset.

## Related issues

Resolves #624 
