### PR TITLE
feat: add external and download icons to links automatically

### DIFF
--- a/src/_includes/svg/icon-download.svg
+++ b/src/_includes/svg/icon-download.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" role="presentation" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M1 11.5v1.75A1.75 1.75 0 0 0 2.75 15h10.5A1.75 1.75 0 0 0 15 13.25V11.5M11.5 8 8 11.5m0 0L4.5 8M8 11.5V1"/></svg>

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -35,18 +35,21 @@ a:focus {
   outline: none;
 }
 
+a[hreflang],
+a[download],
+a[rel="external"] {
+  svg {
+    display: inline-block;
+    margin-left: 0.25em;
+    margin-right: 0.25em;
+    width: 1em;
+  }
+}
+
 a[hreflang] {
-  align-items: center;
-  display: inline-flex;
   font-size: var(--step-1);
   font-weight: var(--fw-semibold);
   margin-top: var(--step-2);
-
-  svg {
-    display: block;
-    margin-right: 0.5em;
-    width: var(--step-1);
-  }
 }
 
 .content a:visited {

--- a/src/assets/styles/base/_typography.scss
+++ b/src/assets/styles/base/_typography.scss
@@ -79,6 +79,11 @@ h4 + *,
   margin-top: rem(30);
 }
 
+* + h5,
+* + .h5 {
+  margin-top: var(--step-2);
+}
+
 @include breakpoint-up(md) {
   :root {
     --step-1: calc(22 / 16 * 1rem);

--- a/src/assets/styles/pages/_generic.scss
+++ b/src/assets/styles/pages/_generic.scss
@@ -80,6 +80,7 @@ main > article {
   }
 }
 
+hr,
 .hr {
   border-bottom: rem(2) solid;
   display: block;

--- a/src/transforms/parse.js
+++ b/src/transforms/parse.js
@@ -39,9 +39,19 @@ module.exports = (value, outputPath) => {
 			for (const link of links) {
 				if (
 					!link.href.startsWith('/') &&
-					(!['localhost:3000', 'idrc.ocadu.ca'].includes(link.host) || !link.host.endsWith('idrc.netlify.app'))
+					(!['localhost:3000', 'localhost:8080', 'idrc.ocadu.ca'].includes(link.host) || !link.host.endsWith('idrc.netlify.app'))
 				) {
 					link.setAttribute('rel', 'external');
+					if (!link.closest('nav')) {
+						link.innerHTML = `${link.innerHTML}<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" role="presentation" aria-hidden="true"><path d="M13.4444 8.77778V13.4444C13.4444 13.857 13.2806 14.2527 12.9888 14.5444C12.6971 14.8361 12.3014 15 11.8889 15H2.55556C2.143 15 1.74733 14.8361 1.45561 14.5444C1.16389 14.2527 1 13.857 1 13.4444V4.11111C1 3.69855 1.16389 3.30289 1.45561 3.01117C1.74733 2.71944 2.143 2.55556 2.55556 2.55556H7.22222V4.11111H2.55556V13.4444H11.8889V8.77778H13.4444ZM8.77778 1V2.55556H12.3447L6.28344 8.61678L7.38322 9.71656L13.4444 3.65533V7.22222H15V1H8.77778Z" fill="currentColor"/></svg>`;
+					}
+				}
+
+				if (
+					link.href.endsWith('.docx') || link.href.endsWith('.pdf')
+				) {
+					link.setAttribute('download', '');
+					link.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" role="presentation" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M1 11.5v1.75A1.75 1.75 0 0 0 2.75 15h10.5A1.75 1.75 0 0 0 15 13.25V11.5M11.5 8 8 11.5m0 0L4.5 8M8 11.5V1"/></svg>${link.innerHTML}`;
 				}
 			}
 		}


### PR DESCRIPTION
* [ ] This pull request has been tested by running `npm run test` without errors
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Adds download and external link icons automatically.

## Steps to test

1. Visit projects page and explore a project, e.g. "Communications Access".

**Expected behavior:** Links to downloadable files are preceded by download icons, and links to external pages are followed by external link icons.

## Additional information

Not applicable.

## Related issues

Not applicable.
