### PR TITLE
fix: resolve header styling on home page

### DIFF
--- a/src/assets/styles/vendors/_uio.scss
+++ b/src/assets/styles/vendors/_uio.scss
@@ -81,5 +81,5 @@
 }
 
 .page--home .fl-prefsEditor-separatedPanel {
-  background: var(--fl-bgColor, var(--white));
+  background: var(--fl-bgColor, var(--white)) !important;
 }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Currently, the site homepage has an issue where the nav bar colour is not the same as the UIO prefs panel colour, leading to an unexpected effect:

<img width="958" alt="Screenshot 2023-06-22 at 10 29 51 AM" src="https://github.com/inclusive-design/idrc/assets/605361/5e7e74bd-f457-4f4f-bbee-9d531189de61">

This PR resolves the issue:

<img width="959" alt="Screenshot 2023-06-22 at 10 30 47 AM" src="https://github.com/inclusive-design/idrc/assets/605361/62a13075-3222-468a-a843-c706cc44a601">


## Steps to test

1. `npm start`
2. Visit the homepage.

**Expected behavior:** UIO bar area and primary nav have the same background colour.

## Additional information

The other pages with different nav bar colours were already working as expected (see, for example, Projects).

## Related issues

Not applicable.