### PR TITLE
Fix interaction styles for the navigation bar and the footer links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@11ty/eleventy-navigation": "0.3.5",
         "@11ty/eleventy-plugin-rss": "1.2.0",
         "d3-selection": "3.0.0",
-        "eleventy-plugin-fluid": "1.0.1",
+        "eleventy-plugin-fluid": "1.0.2",
         "eleventy-plugin-i18n-gettext": "^1.5.1",
         "eleventy-plugin-pwa": "1.0.8",
         "eleventy-plugin-sharp": "0.1.1",
@@ -6240,8 +6240,9 @@
       }
     },
     "node_modules/eleventy-plugin-fluid": {
-      "version": "1.0.1",
-      "license": "BSD-3-Clause",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-1.0.2.tgz",
+      "integrity": "sha512-YW8metiSnqxXGtm2TrTngKHmCxtUlo1EUu/ut/KCk/h2oCnph2Bcc5ozDYmHgJiiDMauThu8xfxmOmhUVVnx5Q==",
       "dependencies": {
         "html-minifier": "4.0.0"
       },
@@ -21426,7 +21427,9 @@
       }
     },
     "eleventy-plugin-fluid": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-fluid/-/eleventy-plugin-fluid-1.0.2.tgz",
+      "integrity": "sha512-YW8metiSnqxXGtm2TrTngKHmCxtUlo1EUu/ut/KCk/h2oCnph2Bcc5ozDYmHgJiiDMauThu8xfxmOmhUVVnx5Q==",
       "requires": {
         "html-minifier": "4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@11ty/eleventy-navigation": "0.3.5",
     "@11ty/eleventy-plugin-rss": "1.2.0",
     "d3-selection": "3.0.0",
-    "eleventy-plugin-fluid": "1.0.1",
+    "eleventy-plugin-fluid": "1.0.2",
     "eleventy-plugin-i18n-gettext": "^1.5.1",
     "eleventy-plugin-pwa": "1.0.8",
     "eleventy-plugin-sharp": "0.1.1",

--- a/src/_includes/layouts/404.njk
+++ b/src/_includes/layouts/404.njk
@@ -3,8 +3,8 @@
 {% set pageType = 'page--404' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="content">
             <div class="wrapper">
             {{ content | safe }}

--- a/src/_includes/layouts/history.njk
+++ b/src/_includes/layouts/history.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--generic' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="content">
             <div class="wrapper">
                 {{ content | safe }}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--home' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         {%- if sections %}
             {%- for section in sections %}
             {% include 'partials/components/section.njk' %}

--- a/src/_includes/layouts/ideas.njk
+++ b/src/_includes/layouts/ideas.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--ideas' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="content">
             <div class="wrapper">
             {% if pagination.pageNumber == 0 %}

--- a/src/_includes/layouts/news.njk
+++ b/src/_includes/layouts/news.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--news' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="content">
             <div class="wrapper">
             {% if posts.length %}

--- a/src/_includes/layouts/page--team.njk
+++ b/src/_includes/layouts/page--team.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--team' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="content">
             <div class="wrapper">
                 <div class="people">

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--generic' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         {%- if sections and sections.length > 0 %}
             {%- for section in sections %}
             {% include 'partials/components/section.njk' %}

--- a/src/_includes/layouts/project.njk
+++ b/src/_includes/layouts/project.njk
@@ -7,10 +7,10 @@
 {% set pageType = 'page--project' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
         {% set articleTitle = title %}
         {% set title = projectName %}
-        {% include 'partials/components/page-header.njk' %}
 
         {% set parentPages = collections.all | eleventyNavigationBreadcrumb(articleTitle) %}
 

--- a/src/_includes/layouts/projects.njk
+++ b/src/_includes/layouts/projects.njk
@@ -7,8 +7,8 @@
 {% set pageType = 'page--projects' %}
 
 {% block content %}
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="projects">
             {% for project in collections['projects_en-CA'] %}
             <article class="project">

--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -34,8 +34,8 @@
         </symbol>
     </svg>
     
+    {% include 'partials/components/page-header.njk' %}
     <article>
-        {% include 'partials/components/page-header.njk' %}
         <div class="resources-container">
             <form method="get" action="/resources/">
                 {% include 'partials/components/filter-resources.njk' %}

--- a/src/_includes/partials/components/page-header.njk
+++ b/src/_includes/partials/components/page-header.njk
@@ -1,4 +1,4 @@
-<header {% if locale !== 'en-CA' %} lang="en-CA" dir="ltr" {% endif %}>
+<header class="page-header" {% if locale !== 'en-CA' %} lang="en-CA" dir="ltr" {% endif %}>
     <div class="wrapper">
         {% set breadcrumbs = [] %}
         {% if eleventyNavigation.key and 'projects' not in page.url %}

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -27,6 +27,7 @@
   'components/image',
   'components/nav',
   'components/nav--secondary',
+  'components/page-header',
   'components/pagination',
   'components/metadata';
 

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -77,6 +77,19 @@ a[rel='external'] {
   }
 }
 
+a[rel='home'] {
+  border: 2px solid;
+  border-radius: 5px;
+  outline: none;
+  &:not(:focus):not(:hover) {
+    // override UIO styles on default state
+    border-bottom-color: transparent !important;
+    border-left-color: transparent !important;
+    border-right-color: transparent !important;
+    border-top-color: transparent !important;
+  }
+}
+
 a[hreflang] {
   font-size: var(--step-1);
   font-weight: var(--fw-semibold);

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -31,14 +31,14 @@ a {
 main,
 footer {
   a {
-    border-radius: 5px;
+    border-radius: rem(5);
   }
 
   a:hover,
   a:focus,
   a:active {
     outline-style: solid;
-    outline-width: 2px;
+    outline-width: rem(3);
   }
 
   a:hover {
@@ -49,8 +49,8 @@ footer {
 
   a:focus {
     outline-color: var(--fl-linkColor, var(--indigo-800));
-    outline-offset: 2px;
-    outline-width: 2px;
+    outline-offset: rem(3);
+    outline-width: rem(3);
   }
 
   a:active {
@@ -78,7 +78,7 @@ a[rel='external'] {
 }
 
 a[rel='home'] {
-  border-radius: 5px;
+  border-radius: rem(5);
 }
 
 a[hreflang] {

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -38,7 +38,7 @@ footer {
   a:focus,
   a:active {
     outline-style: solid;
-    outline-width: 4px;
+    outline-width: 2px;
   }
 
   a:hover {
@@ -78,14 +78,7 @@ a[rel='external'] {
 }
 
 a[rel='home'] {
-  border: 2px solid;
   border-radius: 5px;
-  outline: none;
-
-  &:not(:focus, :hover) {
-    // override UIO styles on default state
-    border-color: transparent !important;
-  }
 }
 
 a[hreflang] {

--- a/src/assets/styles/base/_base.scss
+++ b/src/assets/styles/base/_base.scss
@@ -81,12 +81,10 @@ a[rel='home'] {
   border: 2px solid;
   border-radius: 5px;
   outline: none;
-  &:not(:focus):not(:hover) {
+
+  &:not(:focus, :hover) {
     // override UIO styles on default state
-    border-bottom-color: transparent !important;
-    border-left-color: transparent !important;
-    border-right-color: transparent !important;
-    border-top-color: transparent !important;
+    border-color: transparent !important;
   }
 }
 

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -2,8 +2,7 @@
 
 .nav {
   height: rem(38);
-  margin-left: auto;
-  margin-top: 0;
+  z-index: 20;
 }
 
 .nav .menu-toggle {
@@ -90,6 +89,7 @@
 .menu ul {
   display: flex;
   flex-direction: column;
+  gap: 2px;
   list-style: none;
   padding: 0;
 }
@@ -113,28 +113,27 @@
 
 .menu a,
 .menu button {
+  display: inline-block;
   align-items: center;
-  border: 2px solid;
   border-radius: 5px;
   display: flex;
   font-family: var(--fl-font-family, var(--ff-display));
   font-weight: var(--fw-semibold);
   height: rem(50);
-  outline: none;
   padding: 0 var(--gutter);
+  position: relative;
   text-align: left;
   text-decoration: none;
   width: 100%;
-
-  &:not(:focus, :hover) {
-    // override UIO styles on default state
-    border-color: transparent !important;
-  }
 
   &:hover,
   &:focus {
     background: var(--fl-fgColor, var(--indigo-100));
     color: var(--fl-bgColor, var(--indigo-800));
+    outline-style: solid;
+    outline-width: 2px;
+    outline-color: var(--fl-fgColor, transparent);
+    z-index: 1;
   }
 }
 

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -113,7 +113,6 @@
 
 .menu a,
 .menu button {
-  display: inline-block;
   align-items: center;
   border-radius: 5px;
   display: flex;
@@ -130,9 +129,7 @@
   &:focus {
     background: var(--fl-fgColor, var(--indigo-100));
     color: var(--fl-bgColor, var(--indigo-800));
-    outline-style: solid;
-    outline-width: 2px;
-    outline-color: var(--fl-fgColor, transparent);
+    outline: var(--fl-fgColor, transparent) solid 2px;
     z-index: 1;
   }
 }

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -89,7 +89,7 @@
 .menu ul {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: rem(2);
   list-style: none;
   padding: 0;
 }
@@ -128,7 +128,7 @@
   &:focus {
     background: var(--fl-fgColor, var(--indigo-100));
     color: var(--fl-bgColor, var(--indigo-800));
-    outline: var(--fl-fgColor, transparent) solid 2px;
+    outline: var(--fl-fgColor, transparent) solid rem(3);
     z-index: 1;
   }
 }

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -114,14 +114,25 @@
 .menu a,
 .menu button {
   align-items: center;
+  border: 2px solid;
+  border-radius: 5px;
   display: flex;
   font-family: var(--fl-font-family, var(--ff-display));
   font-weight: var(--fw-semibold);
   height: rem(50);
+  outline: none;
   padding: 0 var(--gutter);
   text-align: left;
   text-decoration: none;
   width: 100%;
+
+  &:not(:focus):not(:hover) {
+     // override UIO styles on default state
+    border-bottom-color: transparent !important;
+    border-left-color: transparent !important;
+    border-right-color: transparent !important;
+    border-top-color: transparent !important;
+  }
 
   &:hover,
   &:focus {

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -114,7 +114,6 @@
 .menu a,
 .menu button {
   align-items: center;
-  border-radius: 5px;
   display: flex;
   font-family: var(--fl-font-family, var(--ff-display));
   font-weight: var(--fw-semibold);

--- a/src/assets/styles/components/_nav.scss
+++ b/src/assets/styles/components/_nav.scss
@@ -126,12 +126,9 @@
   text-decoration: none;
   width: 100%;
 
-  &:not(:focus):not(:hover) {
-     // override UIO styles on default state
-    border-bottom-color: transparent !important;
-    border-left-color: transparent !important;
-    border-right-color: transparent !important;
-    border-top-color: transparent !important;
+  &:not(:focus, :hover) {
+    // override UIO styles on default state
+    border-color: transparent !important;
   }
 
   &:hover,

--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -8,20 +8,32 @@
   position: relative;
 
   .wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: min-content min-content min-content;
     margin: 0;
     margin-left: 50%;
     transform: translateX(-50%);
     width: calc(100vw - var(--gutter));
+
+    h1 {
+      grid-column: 1 / 2;
+      grid-row: 2 / 3;
+    }
   }
 
   .breadcrumbs {
     font-family: var(--fl-font-family, var(--ff-display));
     font-size: var(--step-2);
     font-weight: var(--fw-semibold);
+    grid-column: 1 / 3;
+    grid-row: 1 / 2;
   }
 
   .intro {
     font-size: var(--step--1);
+    grid-column: 1 / 2;
+    grid-row: 3 / 4;
     margin-top: rem(20);
   }
 }

--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -8,13 +8,29 @@
   position: relative;
 
   .wrapper {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: min-content min-content min-content;
     margin: 0;
     margin-left: 50%;
     transform: translateX(-50%);
     width: calc(100vw - var(--gutter));
+  }
+
+  .breadcrumbs {
+    font-family: var(--fl-font-family, var(--ff-display));
+    font-size: var(--step-2);
+    font-weight: var(--fw-semibold);
+  }
+
+  .intro {
+    font-size: var(--step--1);
+    margin-top: rem(20);
+  }
+}
+
+@include breakpoint-up(sm) {
+  .wrapper {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    grid-template-rows: min-content min-content min-content;
 
     h1 {
       grid-column: 1 / 2;
@@ -23,17 +39,12 @@
   }
 
   .breadcrumbs {
-    font-family: var(--fl-font-family, var(--ff-display));
-    font-size: var(--step-2);
-    font-weight: var(--fw-semibold);
     grid-column: 1 / 3;
     grid-row: 1 / 2;
   }
 
   .intro {
-    font-size: var(--step--1);
     grid-column: 1 / 2;
     grid-row: 3 / 4;
-    margin-top: rem(20);
   }
 }

--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -1,27 +1,27 @@
 .page-header {
-    background: var(--fl-bgColor, var(--header-bg, var(--indigo-100)));
-    border-bottom: rem(10) solid var(--fl-fgColor, var(--header-border));
-    color: var(--fl-fgColor, var(--header-fg, $black));
-    flex: 0 0 100%;
-    padding-bottom: rem(80);
-    padding-top: rem(80);
-    position: relative;
+  background: var(--fl-bgColor, var(--header-bg, var(--indigo-100)));
+  border-bottom: rem(10) solid var(--fl-fgColor, var(--header-border));
+  color: var(--fl-fgColor, var(--header-fg, $black));
+  flex: 0 0 100%;
+  padding-bottom: rem(80);
+  padding-top: rem(80);
+  position: relative;
 
-    .wrapper {
-        margin: 0;
-        width: calc(100vw - var(--gutter));
-        margin-left: 50%;
-        transform: translateX(-50%);
-    }
+  .wrapper {
+    margin: 0;
+    margin-left: 50%;
+    transform: translateX(-50%);
+    width: calc(100vw - var(--gutter));
+  }
 
-    .breadcrumbs {
-        font-family: var(--fl-font-family, var(--ff-display));
-        font-size: var(--step-2);
-        font-weight: var(--fw-semibold);
-    }
+  .breadcrumbs {
+    font-family: var(--fl-font-family, var(--ff-display));
+    font-size: var(--step-2);
+    font-weight: var(--fw-semibold);
+  }
 
-    .intro {
-        font-size: var(--step--1);
-        margin-top: rem(20);
-    }
+  .intro {
+    font-size: var(--step--1);
+    margin-top: rem(20);
+  }
 }

--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -1,0 +1,27 @@
+.page-header {
+    background: var(--fl-bgColor, var(--header-bg, var(--indigo-100)));
+    border-bottom: rem(10) solid var(--fl-fgColor, var(--header-border));
+    color: var(--fl-fgColor, var(--header-fg, $black));
+    flex: 0 0 100%;
+    padding-bottom: rem(80);
+    padding-top: rem(80);
+    position: relative;
+
+    .wrapper {
+        margin: 0;
+        width: calc(100vw - var(--gutter));
+        margin-left: 50%;
+        transform: translateX(-50%);
+    }
+
+    .breadcrumbs {
+        font-family: var(--fl-font-family, var(--ff-display));
+        font-size: var(--step-2);
+        font-weight: var(--fw-semibold);
+    }
+
+    .intro {
+        font-size: var(--step--1);
+        margin-top: rem(20);
+    }
+}

--- a/src/assets/styles/layout/_footer.scss
+++ b/src/assets/styles/layout/_footer.scss
@@ -34,8 +34,10 @@
 
 .footer .logo {
   display: flex;
+
   a {
     padding: rem(18);
+
     &[rel='home'] {
       border: none;
     }

--- a/src/assets/styles/layout/_footer.scss
+++ b/src/assets/styles/layout/_footer.scss
@@ -48,8 +48,8 @@
 .footer a {
   &:focus {
     outline-color: var(--fl-linkColor, var(--yellow-500));
-    outline-offset: 2px;
-    outline-width: 2px;
+    outline-offset: rem(3);
+    outline-width: rem(3);
   }
 
   &:hover {

--- a/src/assets/styles/layout/_footer.scss
+++ b/src/assets/styles/layout/_footer.scss
@@ -37,10 +37,6 @@
 
   a {
     padding: rem(18);
-
-    &[rel='home'] {
-      border: none;
-    }
   }
 }
 
@@ -49,10 +45,17 @@
   width: rem(192);
 }
 
-.footer a:hover,
-.footer a:focus {
-  background: var(--fl-linkColor, var(--indigo-500));
-  color: var(--fl-bgColor);
+.footer a {
+  &:focus {
+    outline-color: var(--fl-linkColor, var(--yellow-500));
+    outline-offset: 2px;
+    outline-width: 2px;
+  }
+  &:hover {
+    background: var(--fl-linkColor, var(--indigo-500));
+    color: var(--fl-bgColor);
+    outline-color: var(--fl-linkColor, var(--indigo-500));
+  }
 }
 
 .footer a:visited {

--- a/src/assets/styles/layout/_footer.scss
+++ b/src/assets/styles/layout/_footer.scss
@@ -51,6 +51,7 @@
     outline-offset: 2px;
     outline-width: 2px;
   }
+
   &:hover {
     background: var(--fl-linkColor, var(--indigo-500));
     color: var(--fl-bgColor);

--- a/src/assets/styles/layout/_footer.scss
+++ b/src/assets/styles/layout/_footer.scss
@@ -32,6 +32,16 @@
   padding: 0 calc(var(--gutter) / 2);
 }
 
+.footer .logo {
+  display: flex;
+  a {
+    padding: rem(18);
+    &[rel='home'] {
+      border: none;
+    }
+  }
+}
+
 .footer .logo svg {
   fill: currentcolor;
   width: rem(192);
@@ -41,11 +51,6 @@
 .footer a:focus {
   background: var(--fl-linkColor, var(--indigo-500));
   color: var(--fl-bgColor);
-
-  svg {
-    background-color: var(--fl-linkColor);
-    outline: rem(5) solid var(--fl-linkColor, var(--indigo-500));
-  }
 }
 
 .footer a:visited {

--- a/src/assets/styles/layout/_header.scss
+++ b/src/assets/styles/layout/_header.scss
@@ -35,9 +35,7 @@
   &:focus {
     background: var(--fl-fgColor, var(--black));
     color: var(--fl-bgColor, var(--white));
-    outline-style: solid;
-    outline-width: 2px;
-    outline-color: var(--fl-linkColor, transparent);
+    outline: var(--fl-fgColor, transparent) solid 2px;
   }
 }
 

--- a/src/assets/styles/layout/_header.scss
+++ b/src/assets/styles/layout/_header.scss
@@ -12,7 +12,7 @@
   margin-left: auto;
   margin-right: auto;
   max-width: calc(var(--max-width) + var(--gutter));
-  padding-top: 4px;
+  padding-top: rem(4);
   position: relative;
   width: calc(100vw - var(--gutter));
 
@@ -35,7 +35,7 @@
   &:focus {
     background: var(--fl-fgColor, var(--black));
     color: var(--fl-bgColor, var(--white));
-    outline: var(--fl-fgColor, transparent) solid 2px;
+    outline: var(--fl-fgColor, transparent) solid rem(3);
   }
 }
 

--- a/src/assets/styles/layout/_header.scss
+++ b/src/assets/styles/layout/_header.scss
@@ -8,10 +8,11 @@
   background: var(--fl-bgColor, var(--header-bg, var(--indigo-100)));
   color: var(--fl-fgColor, var(--header-fg, $black));
   display: flex;
+  justify-content: space-between;
   margin-left: auto;
   margin-right: auto;
   max-width: calc(var(--max-width) + var(--gutter));
-  padding: 0;
+  padding-top: 4px;
   position: relative;
   width: calc(100vw - var(--gutter));
 
@@ -26,6 +27,17 @@
     transform: translateX(-50%);
     width: 100vw;
     z-index: -1;
+  }
+}
+
+.banner a {
+  &:hover,
+  &:focus {
+    background: var(--fl-fgColor, var(--black));
+    color: var(--fl-bgColor, var(--white));
+    outline-style: solid;
+    outline-width: 2px;
+    outline-color: var(--fl-linkColor, transparent);
   }
 }
 

--- a/src/assets/styles/pages/_generic.scss
+++ b/src/assets/styles/pages/_generic.scss
@@ -12,45 +12,6 @@ main > article {
   max-width: calc(100vw - var(--gutter));
   width: calc(100vw - var(--gutter));
 
-  header {
-    background: var(--fl-bgColor, var(--header-bg, var(--indigo-100)));
-    border-bottom: rem(10) solid var(--fl-fgColor, var(--header-border));
-    color: var(--fl-fgColor, var(--header-fg, $black));
-    flex: 0 0 100%;
-    padding-bottom: rem(80);
-    padding-top: rem(80);
-    position: relative;
-
-    &::after {
-      background: inherit;
-      border-bottom: rem(10) solid var(--fl-fgColor, var(--header-border));
-      bottom: rem(-10);
-      content: '';
-      display: block;
-      height: calc(100% + #{rem(10)});
-      margin-left: 50%;
-      position: absolute;
-      transform: translateX(-50%);
-      width: 100vw;
-      z-index: -1;
-    }
-
-    .wrapper {
-      margin: 0;
-    }
-
-    .breadcrumbs {
-      font-family: var(--fl-font-family, var(--ff-display));
-      font-size: var(--step-2);
-      font-weight: var(--fw-semibold);
-    }
-
-    .intro {
-      font-size: var(--step--1);
-      margin-top: rem(20);
-    }
-  }
-
   .content {
     flex: 0 0 100%;
     padding-bottom: rem(48);
@@ -65,12 +26,6 @@ main > article {
 @include breakpoint-up(md) {
   main > article {
     max-width: calc(var(--max-width) + var(--gutter));
-
-    header {
-      .wrapper {
-        width: 50%;
-      }
-    }
 
     .content {
       flex: 0 0 calc(100% * 2 / 3);


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

I noticed that focus and hover styles for the items on navigation bar is broken in different themes. I did some investigation and found out that UIO applies different border colours for different themes and we didn't set any border on the navigation bar items, and that caused no focus and hover styles on them. 

An approach I took for the nav bar items are to set transparent border on them all the time by overriding UIO styles, and on focus and hover states, apply correct UIO styles. This way, we can utilize UIO. A potential approach would be not to use UIO, and use outline for the focus and hover styles, but that would be a lot of custom css styles we may maintain in the future as UIO evolves. 

I also noticed that focus and hover styles for items on the footer are off, so I made some adjustment to them.

## Steps to test

1. Check hover styles on live site
2. Compare the styles with the preview of this PR

**Expected behavior:** <!-- What should happen -->

Nav bar items should have proper interaction styles in different themes changed by UIO.