### PR TITLE
fix: resolve page layout regression

### DIFF
--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -27,23 +27,23 @@
 }
 
 @include breakpoint-up(sm) {
-  .page-header{
+  .page-header {
     .wrapper {
       display: grid;
       grid-template-columns: 2fr 1fr;
       grid-template-rows: min-content min-content min-content;
-  
+
       h1 {
         grid-column: 1 / 2;
         grid-row: 2 / 3;
       }
     }
-  
+
     .breadcrumbs {
       grid-column: 1 / 3;
       grid-row: 1 / 2;
     }
-  
+
     .intro {
       grid-column: 1 / 2;
       grid-row: 3 / 4;

--- a/src/assets/styles/components/_page-header.scss
+++ b/src/assets/styles/components/_page-header.scss
@@ -27,24 +27,26 @@
 }
 
 @include breakpoint-up(sm) {
-  .wrapper {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    grid-template-rows: min-content min-content min-content;
-
-    h1 {
-      grid-column: 1 / 2;
-      grid-row: 2 / 3;
+  .page-header{
+    .wrapper {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      grid-template-rows: min-content min-content min-content;
+  
+      h1 {
+        grid-column: 1 / 2;
+        grid-row: 2 / 3;
+      }
     }
-  }
-
-  .breadcrumbs {
-    grid-column: 1 / 3;
-    grid-row: 1 / 2;
-  }
-
-  .intro {
-    grid-column: 1 / 2;
-    grid-row: 3 / 4;
+  
+    .breadcrumbs {
+      grid-column: 1 / 3;
+      grid-row: 1 / 2;
+    }
+  
+    .intro {
+      grid-column: 1 / 2;
+      grid-row: 3 / 4;
+    }
   }
 }


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

In https://github.com/inclusive-design/idrc/pull/642, a regression was introduced in the `.wrapper` class. For small screen sizes and up, the `.wrapper` styles for the page header were applied to generic wrappers as they were not scoped within the `.page-header` class: https://github.com/inclusive-design/idrc/blob/28a4acaf70f3e13be60c31d19c94654f78181852/src/assets/styles/components/_page-header.scss#L29-L50

This PR resolves the issue, removing `grid` rules from the generic `.wrapper` class.

## Steps to test

1. Visit "About" page on the deploy preview.

**Expected behavior:** See expected page layout.

## Additional information

Not applicable.

## Related issues

Not applicable.
