### PR TITLE
feat: add sorting logic for resources

### DIFF
--- a/src/_includes/layouts/resources.njk
+++ b/src/_includes/layouts/resources.njk
@@ -55,6 +55,5 @@
 {% endblock %}
 
 {% block footerScripts %}
-<script src="/assets/scripts/resources-utils.js"></script>
 <script src="/assets/scripts/resources-dynamic-handler.js" defer></script>
 {% endblock %}

--- a/src/assets/scripts/_resources-utils.js
+++ b/src/assets/scripts/_resources-utils.js
@@ -164,18 +164,31 @@ export function htmlDecode(input) {
  */
 export function processResourcesDisplayResults(resources) { // eslint-disable-line no-unused-vars
     const sortedArray = [];
-    const resultsWithPublishedYear = resources.filter(result => result.publishedYear);
-    const resultsWithoutPublishedYear = resources.filter(result => !result.publishedYear);
-    resultsWithPublishedYear.sort((a, b) => {
-        let compare = b.publishedYear.localeCompare(a.publishedYear);
-        if (compare === 0) {
-            compare = a.title.localeCompare(b.title);
-        }
-        return compare;
-    });
-    resultsWithoutPublishedYear.sort((a, b) => (a.title.localeCompare(b.title)));
+    const sortCategory = localStorage.getItem("sortCategory");
+    const isReverse = JSON.parse(localStorage.getItem("reverseSort"));
 
-    sortedArray.push(...resultsWithPublishedYear, ...resultsWithoutPublishedYear);
+    switch (sortCategory) {
+    case "publishedYear":
+        sortedArray.push(...resources.sort((a, b) => (isReverse ? b.publishedYear.localeCompare(a.publishedYear) : a.publishedYear.localeCompare(b.publishedYear))));
+        break;
+    case "title":
+        sortedArray.push(...resources.sort((a, b) => (isReverse ? b.title.localeCompare(a.title) : a.title.localeCompare(b.title))));
+        break;
+    default:
+        const resultsWithPublishedYear = resources.filter(result => result.publishedYear);
+        const resultsWithoutPublishedYear = resources.filter(result => !result.publishedYear);
+        resultsWithPublishedYear.sort((a, b) => {
+            let compare = b.publishedYear.localeCompare(a.publishedYear);
+            if (compare === 0) {
+                compare = a.title.localeCompare(b.title);
+            }
+            return compare;
+        });
+        resultsWithoutPublishedYear.sort((a, b) => (a.title.localeCompare(b.title)));
+
+        sortedArray.push(...resultsWithPublishedYear, ...resultsWithoutPublishedYear);
+        break;
+    }
 
     return sortedArray.map((oneRecord) => {
         oneRecord.title = htmlDecode(oneRecord.title);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [ ] This pull request has been tested by running `npm run test` without errors
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Resolves #518: 
Add sorting logic to the resources page. This work still needs some visual design from designers, but I remember that we paused on this work because designers didn't have enough time on this project. 

## Steps to test

While this PR is in draft mode, only way to check the sorting is by changing the local storage values manually.

1. Go to resources page
2. Open developer console and go to application tab
3. Add key sortCategory in Local Storage with value either _title_ or _publishedYear_
4. You can also add key reverseSort, which takes boolean value true or false
5. Change them around and refresh the page to see the sorting logic

## Additional information

Currently we only have title and publishedYear attributes to sort the resources by, it would probably makes sense to add more attributes for sorting category.


## Related issues

Resolves #518 
