### PR TITLE
fix: resolve slug error

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -438,8 +438,8 @@ collections:
     label: Projects
     label_singular: Project
     folder: src/collections/projects
-    slug: "{{fields.slug}}"
-    preview_path: "/projects/{{fields.slug}}"
+    slug: "{{slug}}"
+    preview_path: "/projects/{{slug}}"
     create: true
     i18n: true
     sortable_fields: [title, order]


### PR DESCRIPTION
Resolves #745.

Unfortunately there appears to be no way to use the customized slug for the preview path but fall back to a URL-safe version of the title if no custom slug is provided.