### PR TITLE
fix: redirect to external ACAW/CAMA page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,5 +38,11 @@ https://websavvy.idrc.ocad.ca/*                                                 
 /projects-and-tools  /projects/   301
 /eds  /projects/eds/   301
 /projects/future-of-work-equitable-digital-systems /projects/eds/ 301
-/projects/accessible-canada-accessible-world /projects/acaw/ 301
 /fr/projects/un-canada-accessible-un-monde-accessible /fr/projets/acaw/ 301
+
+/projects/accessible-canada-accessible-world https://sites.events.concordia.ca/sites/accessconf/en/accessible-canada-accessible-world 301
+/projects/acaw https://sites.events.concordia.ca/sites/accessconf/en/accessible-canada-accessible-world 301
+/fr/projects/un-canada-accessible-un-monde-accessible https://sites.events.concordia.ca/sites/accessconf/fr/accessible-canada-accessible-world 301
+/fr/projects/acaw https://sites.events.concordia.ca/sites/accessconf/fr/accessible-canada-accessible-world 301
+/fr/projets/acaw https://sites.events.concordia.ca/sites/accessconf/fr/accessible-canada-accessible-world 301
+/fr/projets/cama https://sites.events.concordia.ca/sites/accessconf/fr/accessible-canada-accessible-world 301

--- a/src/collections/projects/projects.11tydata.js
+++ b/src/collections/projects/projects.11tydata.js
@@ -1,5 +1,3 @@
-
-
 const { generatePermalink } = require("eleventy-plugin-fluid");
 
 module.exports = {
@@ -8,17 +6,25 @@ module.exports = {
     headerBorderColor: "coral-800",
     headerTextColor: "black",
     eleventyComputed: {
-        langDir: data => data.supportedLanguages[data.locale].dir,
+        langDir: (data) => data.supportedLanguages[data.locale].dir,
         /* Configure navigation */
         eleventyNavigation: {
-            key: data => data.title,
-            parent: data => data.parentTitle || "Projects",
-            order: data => data.subPageOrder
+            key: (data) => data.title,
+            parent: (data) => data.parentTitle || "Projects",
+            order: (data) => data.subPageOrder
         },
         /* Build a permalink using the title or slug and language key. */
-        permalink: data => {
+        permalink: (data) => {
+            if (data.link) {
+                return false;
+            }
+
             const locale = data.locale;
-            return generatePermalink(data, "projects", locale === "fr-CA" ? "projets" : "projects");
+            return generatePermalink(
+                data,
+                "projects",
+                locale === "fr-CA" ? "projets" : "projects"
+            );
         }
     }
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [ ] This pull request has been tested by running `npm run test` without errors
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

Redirects away from old URLs.

## Steps to test

1. Visit /projects/acaw or /fr/projets/cama

**Expected behavior:** Redirect to appropriate page on Concordia website.

## Additional information

Not applicable.

## Related issues

Not applicable.
