### PR TITLE
fix: resource description markdown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         "fluid",
         "plugin:yml/standard",
         "plugin:react/recommended",
-        "plugin:markdown/recommended-legacy"
+        "plugin:markdown/recommended"
     ],
     ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js", "!.github/"],
     env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         "fluid",
         "plugin:yml/standard",
         "plugin:react/recommended",
-        "plugin:markdown/recommended"
+        "plugin:markdown/recommended-legacy"
     ],
     ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js", "!.github/"],
     env: {

--- a/src/assets/scripts/_resources-utils.js
+++ b/src/assets/scripts/_resources-utils.js
@@ -2,6 +2,8 @@
 
 /* exported filterResources, createPagination */
 
+import markdownFilter from "eleventy-plugin-fluid/src/filters/markdown-filter.js";
+
 /*
  * Filter the data set for records that satisfy one or more of the following criteria,
  * - at least one topic in the selected topics
@@ -269,7 +271,12 @@ export function renderResources(resources, resourceTopics, resourceTypes) { // e
         resourcesHtml += `
 				</div>
 				<div class='card-description'>
-					<p>${escapeSpecialCharactersForHTML(resource.description)}</p>
+					<p>${markdownFilter(
+        escapeSpecialCharactersForHTML(resource.description), {
+            html: true,
+            linkify: true,
+            typographer: true
+        }, [])}</p>
 				</div>
 				${resource.publishedYear ? `<div class="card-publishedYear"><p>Published in ${escapeSpecialCharactersForHTML(resource.publishedYear)}</p></div>` : ""}
 				<div class='card-link'><a rel='external' href='${resource.link}'>Visit ${escapeSpecialCharactersForHTML(resource.title)}${resourceLink.host === hostURL ? "" : "<svg role='presentation'><use xlink:href='#external' /></svg>"}</a></div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes the issue where markdown used in resource description was not rendering properly.

## Steps to test

1. Go to admin panel and create a new resource with assets used in its description
2. Check that the assets are displayed properly, if it's a link, it should show link, etc