### PR TITLE
fix: update page header to check for French version of projects in url

### DIFF
--- a/src/_includes/partials/components/page-header.njk
+++ b/src/_includes/partials/components/page-header.njk
@@ -1,7 +1,7 @@
 <header class="page-header" {% if locale !== 'en-CA' %} lang="en-CA" dir="ltr" {% endif %}>
     <div class="wrapper">
         {% set breadcrumbs = [] %}
-        {% if eleventyNavigation.key and 'projects' not in page.url %}
+        {% if eleventyNavigation.key and 'projects' not in page.url and 'projets' not in page.url %}
         {% set breadcrumbs = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key) %}
         {% endif %}
         {% if breadcrumbs.length > 0 %}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

There is an issue with how page-header component renders breadcrumb links for projects page. Update the condition to include French version of projects page to not render link back to projects page.
