### PR TITLE
fix: locale links

### DIFF
--- a/src/_includes/partials/components/page-header.njk
+++ b/src/_includes/partials/components/page-header.njk
@@ -17,12 +17,14 @@
         {% endif %}
         <h1>{{ parentTitle if parentTitle else title }}</h1>
         {% set links = page.url | locale_links %}
+        {% if links.length > 0 %}
         {%- for link in links %}
     
         <a href="{{ link.url }}" lang="{{ link.lang }}" hreflang="{{ link.lang }}">
             {%- include 'svg/icon-translation.svg' -%}<span>{{ 'Read in English' if link.lang === 'en-CA' else 'Lire en français' }}</span>
         </a>
         {%- endfor -%}
+        {% endif %}
         {% if intro %}
         <div class="intro">{{ intro | markdown | safe }}</div>
         {% endif %}


### PR DESCRIPTION
There is an issue on live site where Review of the Review project is showing link to its French content when it doesn't exist; https://idrc.ocadu.ca/projects/rotr/. Weirdly, this doesn't happen in local environment.