### PR TITLE
ci: use Netlify for Lighthouse check again

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,11 +13,14 @@ jobs:
       url: ${{ steps.netlify.outputs.url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: jwalton/gh-find-current-pr/@v1
+        id: find-pr
       - name: Wait for Netlify deploy preview
         uses: kukiron/wait-for-netlify-deploy@v1.2.2
         id: netlify
         with:
           site_name: idrc
+          pr_number: ${{ steps.find-pr.outputs.pr }}
           max_timeout: 300
   lhci-mobile:
     name: Run mobile Lighthouse CI audits

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,16 +10,15 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      url: ${{ steps.cloudflare_preview_url.outputs.url }}
+      url: ${{ steps.netlify.outputs.url }}
     steps:
       - uses: actions/checkout@v4
-      - name: cloudflare-preview-url
-        uses: walshydev/cf-pages-await@v1
-        id: cloudflare_preview_url
+      - name: Wait for Netlify deploy preview
+        uses: kukiron/wait-for-netlify-deploy@v1.2.2
+        id: netlify
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          project: idrc-ocadu-ca
+          site_name: idrc
+          max_timeout: 300
   lhci-mobile:
     name: Run mobile Lighthouse CI audits
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

We're going to keep using Netlify for this site for the time being.