### PR TITLE
fix: tags should not be required

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -530,7 +530,7 @@ collections:
         name: socialImage
         widget: image
         required: false
-      - {label: Tags, name: tags, widget: list, allow_add: true}
+      - {label: Tags, name: tags, widget: list, allow_add: true, required: false}
       - {label: Body, name: body, widget: markdown}
   - name: ideas
     label: Ideas


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Updates CMS admin configuration so that News items no longer require tags.

## Steps to test

1. Start locally
2. Launch in Chrome with the `/admin` route
3. Choose to allow local files
4. Click on 'News'
5. Click on 'New'
6. Notice that the 'Tags' field is no longer marked as required.

**Expected behavior:** <!-- What should happen -->

## Related issues

Resolves #1207 
